### PR TITLE
fixed set_hold_temp()

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -214,8 +214,8 @@ class Ecobee(object):
                       hold_type="nextTransition"):
         ''' Set a hold '''
         body = ('{"functions":[{"type":"setHold","params":{"holdType":"'
-                + hold_type + '","coolHoldTemp":"' + str(cool_temp * 10) +
-                '","heatHoldTemp":"' + str(heat_temp * 10) + '"}}],'
+                + hold_type + '","coolHoldTemp":"' + str(int(cool_temp * 10)) +
+                '","heatHoldTemp":"' + str(int(heat_temp * 10)) + '"}}],'
                 '"selection":{"selectionType":"thermostats","selectionMatch"'
                 ':"' + self.thermostats[index]['identifier'] + '"}}')
         log_msg_action = "set hold temp"


### PR DESCRIPTION
Ecobee's setHold() function requires that both parameters "coolHoldTemp" and "heatHoldTemp" are integers. 

Since set_hold_temp() doesn't do conversion from float to int it was necessary to pass rounded temperature values into the function:
i.e. if I want to set have cool temperature 75.5 and heat temperature 35.3 I would have to pass 76 and 35 and set_hold_temp() would send 760 and 350 to Ecobee.
This fix allows properly passing floats to set_hold_temp()